### PR TITLE
add: 방 상태 변경 버튼 - 모집, 모집완료, 정산완료, 방폭파 추가, 분리

### DIFF
--- a/OrderMate/Model/BoardStructModel.swift
+++ b/OrderMate/Model/BoardStructModel.swift
@@ -6,7 +6,8 @@ struct BoardStructModel: Codable {
     var ownerName: String? // 익명 여부에 따라 이름 혹은 별명
     var title: String
     var createdAt: String? // 명세서 따른 변경, String으로 들어옴
-    var postStatus: String? // 명세서 따른 변경, String으로 들어옴
+    //var postStatus: String? // 명세서 따른 변경, String으로 들어옴
+    var postStatus: PostStatusEnum? // 명세서 따른 변경, String으로 들어옴
     var maxPeopleNum: Int
     var currentPeopleNum: Int
     var isAnonymous: Bool

--- a/OrderMate/Model/PostStatusModel.swift
+++ b/OrderMate/Model/PostStatusModel.swift
@@ -13,11 +13,11 @@ struct PostStatusModel: Codable {
 }
 
 enum PostStatusEnum: String, Codable {
-    case ENDOFROOM = "END_OF_ROOM"
-    case RECRUITING = "RECRUITING"
-    case RECRUITMENTCOMPLETE = "RECRUITMENT_COMPLETE"
-    case ORDERCOMPLETE = "ORDER_COMPLETE"
-    case PAYMENTCOMPLETE = "PAYMENT_COMPLETE"
-    case DELIVERYCOMPLETE = "DELIVERY_COMPLETE"
+    case endOfRoom = "END_OF_ROOM"
+    case recruiting = "RECRUITING"
+    case recruitmentComplete = "RECRUITMENT_COMPLETE"
+    case orderComplete = "ORDER_COMPLETE"
+    case paymentComplete = "PAYMENT_COMPLETE"
+    case deliveryComplete = "DELIVERY_COMPLETE"
 
 }

--- a/OrderMate/View/BoardView/BoardListView.swift
+++ b/OrderMate/View/BoardView/BoardListView.swift
@@ -19,7 +19,7 @@ struct RoomListView: View {
                                                                    pickupSpace: "",
                                                                    spaceType: "",
                                                                    accountNum: "",
-                                                                   estimatedOrderTime: Date(),
+                                                                   estimatedOrderTime: "",
                                                                    ownerId: 1,
                                                                    ownerName: "")]
     @State var recentListArray: [RoomInfoPreview] = [RoomInfoPreview(postId: 99,
@@ -34,7 +34,7 @@ struct RoomListView: View {
                                                                      pickupSpace: "",
                                                                      spaceType: "",
                                                                      accountNum: "",
-                                                                     estimatedOrderTime: Date(),
+                                                                     estimatedOrderTime: "",
                                                                      ownerId: 1,
                                                                      ownerName: "")]
     @State private var showingAlert = false // 로그아웃 alert bool
@@ -117,21 +117,34 @@ struct RoomListView: View {
                             
                             ForEach(listJsonArray, id: \.self) { data in
                                 NavigationLink {
-                                    BoardView(postId: data.postId!)
+                                    if let data = data.postId {
+                                        BoardView(postId: data)
+                                    }
                                 } label: {
                                     HStack {
                                         VStack(alignment: .leading) {
-                                            Text(data.createdAt!.formatISO8601DateToCustom()) // "yy-MM-dd HH:mm"
-                                            Text(data.title!)
-                                                .font(.headline)
-                                            Text("픽업 장소: " + data.pickupSpace!)
+                                            if let createdAt = data.createdAt {
+                                                Text(createdAt.formatISO8601DateToCustom()) // "yy-MM-dd HH:mm"
+                                            }
+                                            if let title = data.title {
+                                                Text(title)
+                                                    .font(.headline)
+                                            }
+                                            if let pickupSpace = data.pickupSpace {
+                                                Text("픽업 장소: " + pickupSpace)
+                                            }
                                             Spacer()
                                         }
                                         Spacer()
                                         VStack(alignment: .trailing) {
-                                            Text(data.postStatus!)
-                                            Text(String(data.currentPeopleNum!) + " / " + String(data.maxPeopleNum!))
-                                            Text("postid: " + String(data.postId!))
+                                            if let postStatus = data.postStatus,
+                                               let currentPeopleNum = data.currentPeopleNum,
+                                               let maxPeopleNum = data.maxPeopleNum,
+                                               let postId = data.postId {
+                                                Text(postStatus)
+                                                Text(String(currentPeopleNum) + " / " + String(maxPeopleNum))
+                                                Text("postid: " + String(postId))
+                                            }
                                             Spacer()
                                         }
                                     }
@@ -154,16 +167,17 @@ struct RoomListView: View {
                             
                             Button {
                                 roomList.uploadData(post: BoardStructModel(ownerName: "버튼테스트3",
-                                                                           title: "버튼테스트", createdAt: "",
-                                                                           postStatus: "RECRUITING",
-                                                                           maxPeopleNum: 5,
-                                                                           currentPeopleNum: 3,
+                                                                           title: "버튼테스트",
+                                                                           createdAt: "",
+                                                                           maxPeopleNum: 2,
+                                                                           currentPeopleNum: 1,
                                                                            isAnonymous: false,
                                                                            content: "버튼테스트",
                                                                            withOrderLink: "버튼테스트",
                                                                            pickupSpace: "버튼테스트",
                                                                            spaceType: "DORMITORY",
-                                                                           accountNum: "버튼테스트")) { success in
+                                                                           accountNum: "버튼테스트",
+                                                                           estimatedOrderTime: "2023-02-05T12:59:11.332")) { success in
                                     if success {
                                         print("방생성완료")
                                     } else {
@@ -186,7 +200,6 @@ struct RoomListView: View {
                     recentListArray = data as! [RoomInfoPreview]
                 }
             }
-            
         }
         .onAppear {
             // user Info 받아오기

--- a/OrderMate/View/BoardView/BoardView.swift
+++ b/OrderMate/View/BoardView/BoardView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BoardView: View {
+    @Environment(\.presentationMode) var presentationMode
     var postId: Int
     @EnvironmentObject var userManager: UserViewModel // user Info 받아오기
     @State private var isCompleted: Bool = false // 방이 모집완료인지 체크
@@ -17,6 +18,9 @@ struct BoardView: View {
     @State private var isHost: Bool = false // 방장인지 체크 // array 조회로 대체
     
     @State private var isShowLockAlert: Bool = false // 방 잠금 alert용
+    @State private var isShowUnlockAlert: Bool = false // 방 잠금해제 alert용
+    @State private var isShowCompleteAlert: Bool = false // 방 완료 alert용
+    @State private var isShowDeleteAlert: Bool = false // 방 폭파 alert용
     
     @StateObject var manager: BoardViewModel = BoardViewModel.shared
     
@@ -29,24 +33,36 @@ struct BoardView: View {
                         HStack {
                             Text("안녕하세요, \(userManager.userModel.name)")
                             Spacer()
-                            Text(board.createdAt!.formatISO8601DateToCustom())
-                                .font(.subheadline)
-                                .foregroundColor(.gray)
+                            if let createdAt = board.createdAt {
+                                Text(createdAt.formatISO8601DateToCustom())
+                                    .font(.subheadline)
+                                    .foregroundColor(.gray)
+                            }
                         }.padding()
                         
-                        VStack {
-                            if let board = manager.board {
-                                Text("\(board.title)")
+                        HStack {
+                            VStack {
+                                if let board = manager.board {
+                                    Text("\(board.title)")
+                                        .font(.system(size: 20))
+                                        .bold()
+                                        .frame(maxWidth: .infinity, minHeight: 30)
+                                        .foregroundColor(.black)
+                                } else {
+                                    Text("N/A")
+                                }
+                                
+                            }
+                            Spacer()
+                            if let postStatus = board.postStatus?.rawValue {
+                                Text("\(postStatus)")
                                     .font(.system(size: 20))
                                     .bold()
                                     .frame(maxWidth: .infinity, minHeight: 30)
                                     .foregroundColor(.black)
-                            } else {
-                                Text("N/A")
                             }
-
-                        }
-                        .padding()
+                        }.padding()
+                        
                         VStack {
                             // 다른 정보들도 넣을 수 있도록 칸 변경 2x2 모양이 가장 깔끔할 것 같음
                             HStack {
@@ -59,7 +75,9 @@ struct BoardView: View {
                         VStack {
                             HStack {
                                 Text("\(board.isAnonymous ? "비공개글" : "공개글")").customBoardInfo()
-                                Text(board.ownerName!).customBoardInfo()
+                                if let ownerName = board.ownerName {
+                                    Text(ownerName).customBoardInfo()
+                                }
                             }
                         }.padding(.horizontal)
                         
@@ -83,41 +101,119 @@ struct BoardView: View {
                                 Text("\(name) (\(role))")
                             }
                             
-                            if board.postStatus == PostStatusEnum.RECRUITING.rawValue {
-                                Button {
-                                    isShowLockAlert = true
-                                } label: {
-                                    Text("인원 마감")
-                                        .font(.title2)
-                                        .fontWeight(.semibold)
-                                }.alert(isPresented: $isShowLockAlert) {
-                                    Alert(title: Text("인원을 마감하시겠습니까?"),
-                                          message: Text("마감하면 새로운 사람이 들어올 수 없습니다"),
-                                          primaryButton: .destructive(Text("마감"), action: {
-                                        // 방 상태 변경 함수
-                                        manager.goNextFromRecruiting(postId: postId) { status in
-                                            if status {
-                                                isCompleted = true
-                                                // 방잠금으로 새로 고침
-                                                manager.getBoard(postId: postId) { isComplete in
-                                                    if isComplete {
-                                                        manager.processBoardInfo(userModel: userModel) { _, isHost, isCompleted, isEntered in
-                                                            self.isHost = isHost
-                                                            self.isCompleted = isCompleted
-                                                            self.isEntered = isEntered
+                            if let postStatus = board.postStatus {
+                                VStack {
+                                    HStack {
+                                        Button {
+                                            isShowUnlockAlert = true
+                                        } label: {
+                                            HStack {
+                                                Text("모집하기")
+                                                    .font(.title2)
+                                                    .fontWeight(.semibold)
+                                                
+                                            }.padding()
+                                        }.alert(isPresented: $isShowUnlockAlert) {
+                                            Alert(title: Text("모집하시겠습니까?"),
+                                                  message: Text("새로운 사람이 들어올수있습니다"),
+                                                  primaryButton: .destructive(Text("모집하기"), action: {
+                                                // 방 상태 변경 함수
+                                                manager.changeToRecruiting(postId: postId) { status in
+                                                    if status {
+                                                        isCompleted = false
+                                                        // 방잠금으로 새로 고침
+                                                        manager.getBoard(postId: postId) { isComplete in
+                                                            if isComplete {
+                                                                manager.processBoardInfo(userModel: userModel) { _, isHost, isCompleted, isEntered in
+                                                                    self.isHost = isHost
+                                                                    self.isCompleted = isCompleted
+                                                                    self.isEntered = isEntered
+                                                                }
+                                                            }
                                                         }
+                                                        
+                                                    } else {
+                                                        
                                                     }
                                                 }
-                                                
-                                            } else {
-                                                
-                                            }
+                                            }), secondaryButton: .cancel(Text("취소")))
                                         }
-                                    }), secondaryButton: .cancel(Text("취소")))
+                                        Button {
+                                            isShowLockAlert = true
+                                        } label: {
+                                            HStack {
+                                                Text("모집 마감")
+                                                    .font(.title2)
+                                                    .fontWeight(.semibold)
+                                                
+                                            }.padding()
+                                        }.alert(isPresented: $isShowLockAlert) {
+                                            Alert(title: Text("모집 마감하시겠습니까?"),
+                                                  message: Text("마감하면 새로운 사람이 들어올 수 없습니다"),
+                                                  primaryButton: .destructive(Text("다음 단계"), action: {
+                                                // 방 상태 변경 함수
+                                                manager.changeToRecruitingComplete(postId: postId) { status in
+                                                    if status {
+                                                        isCompleted = true
+                                                        // 방잠금으로 새로 고침
+                                                        manager.getBoard(postId: postId) { isComplete in
+                                                            if isComplete {
+                                                                manager.processBoardInfo(userModel: userModel) { _, isHost, isCompleted, isEntered in
+                                                                    self.isHost = isHost
+                                                                    self.isCompleted = isCompleted
+                                                                    self.isEntered = isEntered
+                                                                }
+                                                            }
+                                                        }
+                                                    } else {
+                                                    }
+                                                }
+                                            }), secondaryButton: .cancel(Text("취소")))
+                                        }
+                                    }
+                                    Button {
+                                        isShowCompleteAlert = true
+                                    } label: {
+                                        HStack {
+                                            Text("수령 및 결제 완료 처리")
+                                                .font(.title2)
+                                                .fontWeight(.semibold)
+                                            
+                                        }.padding()
+                                    }.alert(isPresented: $isShowCompleteAlert) {
+                                        Alert(title: Text("모든게 끝났나요?"),
+                                              message: Text("마무리됩니다"),
+                                              primaryButton: .destructive(Text("끝났어요"), action: {
+                                            // 방 상태 변경 함수
+                                            manager.changeBoardComplete(postId: postId) { status in
+                                                if status {
+                                                    isCompleted = true
+                                                    // 방잠금으로 새로 고침
+                                                    manager.getBoard(postId: postId) { isComplete in
+                                                        if isComplete {
+                                                            manager.processBoardInfo(userModel: userModel) { _, isHost, isCompleted, isEntered in
+                                                                self.isHost = isHost
+                                                                self.isCompleted = isCompleted
+                                                                self.isEntered = isEntered
+                                                            }
+                                                        }
+                                                    }
+                                                    
+                                                } else {
+                                                    
+                                                }
+                                            }
+                                        }), secondaryButton: .cancel(Text("취소")))
+                                    }
+                                    
+                                    
+                                    
+                                    
+                                    
                                 }
                             }
                         }
-
+                        
                         Spacer()
                         statePeopleView
                         // 참가 안한 상태고 방이 잠기지 않으면
@@ -168,12 +264,16 @@ struct BoardView: View {
                                                     self.isHost = isHost
                                                     self.isCompleted = isCompleted
                                                     self.isEntered = isEntered
+
                                                 }
                                             }
                                         }
-                                        
+                                        DispatchQueue.main.async {
+                                            self.presentationMode.wrappedValue.dismiss()
+                                        }
                                     }
                                 }
+                                
                             } label: {
                                 Text("방 나가기")
                                     .font(.system(size: 24))

--- a/OrderMate/ViewModel/BoardStruct.swift
+++ b/OrderMate/ViewModel/BoardStruct.swift
@@ -7,57 +7,57 @@
 
 import Foundation
 
-struct Board: Hashable, Identifiable, Codable {
-    var id: String
-    var title: String
-    var location: String
-    var date: Date
-    var maxUser: Int
-    var userList: [String] = []
-}
+//struct Board: Hashable, Identifiable, Codable {
+//    var id: String
+//    var title: String
+//    var location: String
+//    var date: Date
+//    var maxUser: Int
+//    var userList: [String] = []
+//}
 
-struct CreatBoard: Codable {
-    var title: String
-    var maxPeopleNum: String
-    var isAnonymous: Int?
-    var spaceType: String?
-    var content: String
-    var withOrderLink: String?
-    var pickupSpace: String?
-    var accountNum: String?
-    var estimatedOrdTime: String?
-   
-}
+//struct CreatBoard: Codable {
+//    var title: String
+//    var maxPeopleNum: String
+//    var isAnonymous: Int?
+//    var spaceType: String?
+//    var content: String
+//    var withOrderLink: String?
+//    var pickupSpace: String?
+//    var accountNum: String?
+//    var estimatedOrdTime: String?
+//
+//}
 
-struct UploadData {
-    var title: String
-    var maxPeopleNum: String
-    var isAnonymous: Int
-    var spaceType: String
-    var content: String
-    var withOrderLink: String
-    var pickupSpace: String
-    var accountNum: String
-    var estimatedOrdTime: String
-}
-
-struct RoomInfo: Decodable {
-    let postId: Int?
-    let title: String?
-    let createdAt: Date?
-    let postStatus: String?
-    let maxPeopleNum: Int?
-    let currentPeopleNum: Int?
-    let isAnonymous: Bool?
-    let content: String?
-    let withOrderLink: String?
-    let pickupSpace: String?
-    let spaceType: String?
-    let accountNum: String?
-    let estimatedOrderTime: Date?
-    let ownerId: Int?
-    let ownerName: String?
-}
+//struct UploadData {
+//    var title: String
+//    var maxPeopleNum: String
+//    var isAnonymous: Int
+//    var spaceType: String
+//    var content: String
+//    var withOrderLink: String
+//    var pickupSpace: String
+//    var accountNum: String
+//    var estimatedOrdTime: String
+//}
+//
+//struct RoomInfo: Decodable {
+//    let postId: Int?
+//    let title: String?
+//    let createdAt: Date?
+//    let postStatus: String?
+//    let maxPeopleNum: Int?
+//    let currentPeopleNum: Int?
+//    let isAnonymous: Bool?
+//    let content: String?
+//    let withOrderLink: String?
+//    let pickupSpace: String?
+//    let spaceType: String?
+//    let accountNum: String?
+//    let estimatedOrderTime: Date?
+//    let ownerId: Int?
+//    let ownerName: String?
+//}
 
 // boardListView용 데이터...struct RoomInfo와 달라야하는지 리뷰 필요
 struct RoomInfoPreview: Codable, Hashable {
@@ -73,7 +73,7 @@ struct RoomInfoPreview: Codable, Hashable {
     let pickupSpace: String?
     let spaceType: String?
     let accountNum: String?
-    let estimatedOrderTime: Date?
+    let estimatedOrderTime: String?
     let ownerId: Int? // 아이디별 고유 넘버링
     let ownerName: String? // 익명 여부에 따라 이름 혹은 별명
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[V] 기능 추가
-[] 기능 삭제
-[V] 버그 수정
-[V] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat-8 -> dev

### 변경 사항
estimatedOrderTime이 작동하게 변경했습니다
estimatedOrderTime: Date()를 String으로 변경했습니다
리팩토링시 Date로 변경하려하는데 지금 문제가 있는지 알려주세요 Date포메팅 우선 진행 후 pr 다시 하겠습니다

BoardView의 모든 포스 언래퍼와
RoomListView의 일부 포스 언래퍼를 if let 으로 변경했습니다

BoardView에 방 상태 변경 버튼을 종류 별로 추가 했습니다
현재 방상태를 제목 오른쪽에 나타나게 했습니다

BoardStructModel의 postStatus를
postStatus: String?에서
postStatus: PostStatusEnum?으로 변경했습니다

PostStatusEnum 모델을 카멜케이스로 변경했습니다

OrderMate/ViewModel/BoardStruct.swift의 사용하지 않는 모델 일부를 주석 처리했습니다
사용하는 모델이 있다면 알려주세요


### 테스트 결과

![스크린샷 2023-04-11 오후 8 54 27](https://user-images.githubusercontent.com/92566655/231156743-5b431f4d-e90b-441e-8d52-17254ddb9370.png)
![스크린샷 2023-04-11 오후 8 53 53](https://user-images.githubusercontent.com/92566655/231156748-ceb16eb8-09a8-4003-8118-65a49169cbb6.png)
